### PR TITLE
chore: fix cmake path and document scripted build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cmake.sourceDirectory": "C:/Users/Grorian/Documents/GitHub/ZenithEngine/ZenithEngine"
+    "cmake.sourceDirectory": "${workspaceFolder}"
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@
 
 ### Build Instructions
 
+On Windows, the easiest way to get started is to run the provided
+`InstallAndBuild.cmd` script. It will install the required build tools and
+dependencies via **vcpkg**, then configure and build the project:
+
+```bat
+InstallAndBuild.cmd
+```
+
+If you prefer to configure the project manually or are on another platform,
+you can follow the standard CMake workflow:
+
 ```sh
 # Clone the repository
  git clone --recursive <repo_url>


### PR DESCRIPTION
## Summary
- replace hard-coded VSCode CMake path with workspace-relative value
- document InstallAndBuild.cmd as one-click Windows setup

## Testing
- `cmake ..` *(fails: Could not find toolchain file /workspace/ZenithEngine/vcpkg/scripts/buildsystems/vcpkg.cmake)*
- `git submodule update --init --recursive` *(fails: unable to access https://github.com/microsoft/vcpkg.git/ 403)*